### PR TITLE
Change `was` to `were` in the caching page.

### DIFF
--- a/views/caching.html
+++ b/views/caching.html
@@ -9,7 +9,7 @@
         <ul class="inline-disc">
             <li>Internal &mdash; This is an in-memory store per <a href="//nodejs.org">node process</a>, the language the API server is written in.</li>
             <li>Redis &mdash; We have a Redis cache in place for regions where multiple backend servers are running.</li>
-            <li>Varnish &mdash; We now also have a varnish cache in place, this replaced some cloudflare caching rules we had, which was less effective.</li>
+            <li>Varnish &mdash; We now also have a varnish cache in place, this replaced some cloudflare caching rules we had, which were less effective.</li>
         </ul>
         <p><strong>How long do you cache for?</strong></p>
         <p>It depends which API you are querying, please see the table below for cache duration.</p>


### PR DESCRIPTION
The newline was added by the Github editor, sorry.